### PR TITLE
[Feat]: 优化单集进度按钮 UI

### DIFF
--- a/app/src/main/java/com/xiaoyv/bangumi/ui/media/action/MediaEpActionDialog.kt
+++ b/app/src/main/java/com/xiaoyv/bangumi/ui/media/action/MediaEpActionDialog.kt
@@ -103,7 +103,7 @@ class MediaEpActionDialog : DialogFragment() {
                 return@addOnButtonCheckedListener
             }
 
-            var saveTypeEps: List<String>
+            val saveTypeEps: List<String>
             when (i) {
                 // 想看
                 R.id.btn_wish -> {
@@ -120,21 +120,32 @@ class MediaEpActionDialog : DialogFragment() {
                     saveTypeEps = listOf(userEp.id)
                     userEp.type = EpCollectType.TYPE_COLLECT
                 }
-                // 看到
-                R.id.btn_collect_to -> {
-                    saveTypeEps = watchedIds
-                    userEp.type = EpCollectType.TYPE_COLLECT
-                }
-                // 撤销
-                else -> {
-                    saveTypeEps = listOf(userEp.id)
-                    userEp.type = EpCollectType.TYPE_NONE
-                }
+                else -> return@addOnButtonCheckedListener
             }
 
             // 保存
             saveEpCollectStatus(
                 saveTypeEps,
+                subjectId = userEp.episode?.subjectId.toString(),
+                type = userEp.type
+            )
+        }
+
+        // 看到
+        binding.btnCollectTo.setOnClickListener {
+            userEp.type = EpCollectType.TYPE_COLLECT
+            saveEpCollectStatus(
+                watchedIds,
+                subjectId = userEp.episode?.subjectId.toString(),
+                type = userEp.type
+            )
+        }
+
+        // 撤销
+        binding.btnRemove.setOnClickListener {
+            userEp.type = EpCollectType.TYPE_NONE
+            saveEpCollectStatus(
+                listOf(userEp.id),
                 subjectId = userEp.episode?.subjectId.toString(),
                 type = userEp.type
             )

--- a/app/src/main/res/layout/fragment_media_action_ep.xml
+++ b/app/src/main/res/layout/fragment_media_action_ep.xml
@@ -54,13 +54,16 @@
 
     <com.google.android.material.button.MaterialButtonToggleGroup
         android:id="@+id/gp_buttons"
-        android:layout_width="match_parent"
+        android:layout_width="@dimen/ui_size_0"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/ui_layout_margin"
+        android:layout_marginStart="@dimen/ui_layout_margin"
+        android:layout_marginEnd="@dimen/ui_layout_margin_compat"
         android:layout_marginTop="@dimen/ui_layout_margin"
         android:layout_marginBottom="@dimen/ui_layout_margin"
         android:gravity="center"
         app:layout_constrainedHeight="true"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/btn_collect_to"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tv_comment"
         app:layout_constraintVertical_bias="0"
@@ -88,16 +91,6 @@
             android:textAppearance="?attr/textAppearanceBodyMedium" />
 
         <com.xiaoyv.common.widget.button.AnimeButton
-            android:id="@+id/btn_collect_to"
-            style="@style/Widget.Material3.Button.OutlinedButton"
-            android:layout_width="@dimen/ui_size_0"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:padding="@dimen/ui_size_0"
-            android:text="看到"
-            android:textAppearance="?attr/textAppearanceBodyMedium" />
-
-        <com.xiaoyv.common.widget.button.AnimeButton
             android:id="@+id/btn_dropped"
             style="@style/Widget.Material3.Button.OutlinedButton"
             android:layout_width="@dimen/ui_size_0"
@@ -106,17 +99,33 @@
             android:padding="@dimen/ui_size_0"
             android:text="抛弃"
             android:textAppearance="?attr/textAppearanceBodyMedium" />
-
-        <com.xiaoyv.common.widget.button.AnimeButton
-            android:id="@+id/btn_remove"
-            style="@style/Widget.Material3.Button.OutlinedButton"
-            android:layout_width="@dimen/ui_size_0"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:padding="@dimen/ui_size_0"
-            android:text="撤销"
-            android:textAppearance="?attr/textAppearanceBodyMedium" />
     </com.google.android.material.button.MaterialButtonToggleGroup>
+
+    <com.xiaoyv.common.widget.button.AnimeButton
+        android:id="@+id/btn_collect_to"
+        style="@style/Widget.Material3.Button.IconButton.Outlined"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/ui_layout_margin_compat"
+        android:tooltipText="看到"
+        app:layout_constraintEnd_toStartOf="@id/btn_remove"
+        app:layout_constraintTop_toTopOf="@id/gp_buttons"
+        app:layout_constraintBottom_toBottomOf="@id/gp_buttons"
+        app:icon="@drawable/ic_collect_to"
+        app:iconTint="?attr/colorOnSurface" />
+
+    <com.xiaoyv.common.widget.button.AnimeButton
+        android:id="@+id/btn_remove"
+        style="@style/Widget.Material3.Button.IconButton.Outlined"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/ui_layout_margin"
+        android:tooltipText="撤销"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/gp_buttons"
+        app:layout_constraintBottom_toBottomOf="@id/gp_buttons"
+        app:icon="@drawable/ic_undo"
+        app:iconTint="?attr/colorOnSurface" />
 
     <com.xiaoyv.common.widget.image.AnimeImageView
         android:id="@+id/iv_cancel"

--- a/lib-common/src/main/res/drawable/ic_collect_to.xml
+++ b/lib-common/src/main/res/drawable/ic_collect_to.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M760,600Q709,600 674.5,565.5Q640,531 640,480Q640,429 674.5,394.5Q709,360 760,360Q811,360 845.5,394.5Q880,429 880,480Q880,531 845.5,565.5Q811,600 760,600ZM360,680L304,623L407,520L80,520L80,440L407,440L304,336L360,280L560,480L360,680Z"/>
+</vector>

--- a/lib-common/src/main/res/drawable/ic_undo.xml
+++ b/lib-common/src/main/res/drawable/ic_undo.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal"
+    android:autoMirrored="true">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M280,760L280,680L564,680Q627,680 673.5,640Q720,600 720,540Q720,480 673.5,440Q627,400 564,400L312,400L416,504L360,560L160,360L360,160L416,216L312,320L564,320Q661,320 730.5,383Q800,446 800,540Q800,634 730.5,697Q661,760 564,760L280,760Z"/>
+</vector>

--- a/lib-common/src/main/res/values/dimens.xml
+++ b/lib-common/src/main/res/values/dimens.xml
@@ -1,5 +1,6 @@
 <resources>
     <dimen name="ui_layout_margin">16dp</dimen>
+    <dimen name="ui_layout_margin_compat">8dp</dimen>
     <dimen name="home_card_height">200dp</dimen>
     <dimen name="text_margin">16dp</dimen>
     <dimen name="text_label">10sp</dimen>


### PR DESCRIPTION
将“看到”和“撤销”这两个非状态的按钮从segmented buttons group里拿出来单独展示为icon buttons。

![Screenshot_20240418_175802](https://github.com/xiaoyvyv/bangumi/assets/7088631/24474485-1d1b-4c2a-83c0-63e97e4322d5)

