### PR TITLE
[Feat]: 暗色模式启动屏改为暗色背景

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,15 @@
+<resources>
+    <style name="Theme.App.Starting" parent="Theme.SplashScreen">
+        <!-- Set the splash screen background, animated icon, and animation duration. -->
+        <item name="windowSplashScreenBackground">?android:colorBackground</item>
+
+        <!-- 用圆形白底的图标来保证在暗色背景上站是正常 -->
+        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_0</item>
+        <!-- Required for animated icons -->
+        <item name="windowSplashScreenAnimationDuration">200</item>
+
+        <!-- Set the theme of the Activity that directly follows your splash screen. -->
+        <!-- Required -->
+        <item name="postSplashScreenTheme">@style/Theme.Bangumi</item>
+    </style>
+</resources>


### PR DESCRIPTION
暗色模式使用暗色背景，同时把引用的图标资源从foreground改为整个图标。

![cd460026eb0e60584d21e45751efb7bd_720](https://github.com/xiaoyvyv/bangumi/assets/7088631/ed53c765-952b-4e84-b617-eb01b7acef07)
